### PR TITLE
my_video_captureフォルダが余分な階層に存在する問題

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="MyVideoCapture",
-    version="1.0.0",
+    version="1.0.1",
     description="read camera",
     url="https://github.com/a-nemoto313/video-capture-for-tiscam",
     packages=["my_video_capture"],


### PR DESCRIPTION
venv/my_videp_capture/TIS_UDSHL11_x64.dll
venv/my_video_capture/tisgrabber_x64.dll
と不要なフォルダが作成されてしまっているため、data_filesに指定するパスを [("配布先のディレクトリの相対パス"、["配布したいデータファイルのsetup.pyからの相対パス"])] と変更。